### PR TITLE
Limited number of days for weather report

### DIFF
--- a/daily_post.py
+++ b/daily_post.py
@@ -21,23 +21,32 @@ subreddit = reddit.subreddit('SeattleWA')
 
 now = datetime.datetime.now()
 
+
 def get_weather():
     resp = requests.get('http://forecast.weather.gov/MapClick.php?lat=47.62&lon=-122.36&unit=0&lg=english&FcstType=text&TextType=1')
     doc = resp.content
     soup_doc = BeautifulSoup(doc, 'html.parser')
-    weather_info = soup_doc.find_all('table')[1]
-    forecast = str(weather_info.contents[0]).split("<br/>\n<br/>")
-    top_three = '<br/>\n<br/>'.join(str(x) for x in forecast[1:3])
+    weather_info = soup_doc.find_all('table')[1].contents[0].contents[0]
+    reddit_comment = ''
+    if len(weather_info.find_all('div')) > 0:
+        advisories = weather_info.div.extract().find_all('a')
+        reddit_comment += '* Advisories: \n'
+        for advis in advisories:
+            reddit_comment += ' * ' + advis.span.string + ' \n'
+    forecast = str(weather_info).split("<br/>\n<br/>")
+    top_three = '<br/>\n<br/>'.join(str(x) for x in forecast[1:5])
     top_three_doc = BeautifulSoup(top_three, 'html.parser')
-    reddit_comment = '* ' + str.replace(top_three_doc.text, '\n\n',"\n* ")[:-3]
+    reddit_comment += '* ' + str.replace(top_three_doc.text, '\n\n', "\n* ")[:-3]
 
-    return(reddit_comment)
+    return reddit_comment
+
 
 def gen_post():
     j2_env = Environment(loader=FileSystemLoader('./templates'),trim_blocks=True)
     template = j2_env.get_template('daily_post.j2')
 
-    return(template.render(forecast=get_weather()))
+    return template.render(forecast=get_weather())
+
 
 subreddit.submit(title=now.strftime("Seattle Reddit Community Open Chat, %A, %B %d, %Y"),
                  selftext=gen_post(),

--- a/daily_post.py
+++ b/daily_post.py
@@ -26,8 +26,10 @@ def get_weather():
     doc = resp.content
     soup_doc = BeautifulSoup(doc, 'html.parser')
     weather_info = soup_doc.find_all('table')[1]
-    forecast = weather_info.contents[0].text
-    reddit_comment = '* ' + str.replace(forecast, '\n\n',"\n* ")[:-3]
+    forecast = str(weather_info.contents[0]).split("<br/>\n<br/>")
+    top_three = '<br/>\n<br/>'.join(str(x) for x in forecast[1:3])
+    top_three_doc = BeautifulSoup(top_three, 'html.parser')
+    reddit_comment = '* ' + str.replace(top_three_doc.text, '\n\n',"\n* ")[:-3]
 
     return(reddit_comment)
 
@@ -37,9 +39,8 @@ def gen_post():
 
     return(template.render(forecast=get_weather()))
 
-
-subreddit.submit(title=now.strftime("Seattle Reddit Community Open Chat, %A, %B %d, %Y"), 
+subreddit.submit(title=now.strftime("Seattle Reddit Community Open Chat, %A, %B %d, %Y"),
                  selftext=gen_post(),
-                 url=None, 
-                 resubmit=True, 
+                 url=None,
+                 resubmit=True,
                  send_replies=False)

--- a/templates/daily_post.j2
+++ b/templates/daily_post.j2
@@ -14,7 +14,7 @@ Welcome to the [Seattle Reddit Community](https://www.reddit.com/r/SeattleWA) Da
 
 ---
 
-7-Day Weather forecast for the /r/SeattleWA metro area from the NWS:
+2-Day Weather forecast for the /r/SeattleWA metro area from the NWS:
 
 {{ forecast }}
 


### PR DESCRIPTION
I limited the number of days for the weather report to the 2nd and 3rd entries in the list. Based on the time of night the bot normally runs this should limit the displayed information to the current day and current night. Skipping Tonight and the rest of the forecast.

Tweaking line 30 changes how many forecast entries are shown.