### PR TITLE
Fix bug in regex, fix bug in selecting weather forecast periods

### DIFF
--- a/daily_post.py
+++ b/daily_post.py
@@ -34,7 +34,7 @@ def _convert_time_str_to_datetime(time: str) -> datetime.datetime:
 
 def get_weather_emoji(period: Dict[str, Any]) -> Optional[str]:
     # only get the first phrase in the short forecast
-    match = re.fullmatch(r'((?:[A-Z]\w+ )+[A-Z]\w+)', period['shortForecast'])
+    match = re.match(r'^((?:[A-Z]\w+ )+[A-Z]\w+)', period['shortForecast'])
     if match is None:
         return None
 
@@ -73,8 +73,9 @@ def get_weather(client: praw.Reddit) -> str:
 
     # TODO: I vaguely remember there being a way to get advisories. Can't find it right now for some reason though
     current_date = datetime.date.today()
+    tomorrow = current_date + datetime.timedelta(days=1)
     forecast_periods = [period for period in data['properties']['periods']
-                        if _convert_time_str_to_datetime(period['startTime']).date() >= current_date][:4]
+                        if current_date <= _convert_time_str_to_datetime(period['startTime']).date() <= tomorrow]
     comment_lines = []
     emoji_fails = []
 
@@ -119,8 +120,10 @@ if __name__ == '__main__':
     now = datetime.datetime.now()
     post = gen_post(now.weekday(), reddit)
 
+    """
     subreddit.submit(title=now.strftime("Seattle Reddit Community Open Chat, %A, %B %d, %Y"),
                      selftext=post,
                      url=None,
                      resubmit=True,
                      send_replies=False)
+    """

--- a/daily_post.py
+++ b/daily_post.py
@@ -120,10 +120,8 @@ if __name__ == '__main__':
     now = datetime.datetime.now()
     post = gen_post(now.weekday(), reddit)
 
-    """
     subreddit.submit(title=now.strftime("Seattle Reddit Community Open Chat, %A, %B %d, %Y"),
                      selftext=post,
                      url=None,
                      resubmit=True,
                      send_replies=False)
-    """


### PR DESCRIPTION
Regex bug: `re.fullmatch('((?:[A-Z]\w+ )+[A-Z]\w+)', forecast)` doesn't match `Mostly Cloudy then Slight Chance Rain Showers`. Changed to just `re.match` but used `^` to assert beginning of string

Forecast period bug: we only get 4 periods every time, but the API doesn't work that way and we end up getting a period from 2-6am and losing the period for tomorrow night. Changed it to just check for start date between today and tomorrow.